### PR TITLE
Add graphviz DOT generation

### DIFF
--- a/tealview.js
+++ b/tealview.js
@@ -118,7 +118,8 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
     var returnMatch = line.match(/^return.*/);
     var callsubMatch = line.match(/^callsub\s+(.*)/);
     var retsubMatch = line.match(/^retsub.*/);
-    if ((returnMatch || retsubMatch) && !wasReturn) {
+    var errMatch = line.match(/^err.*/);
+    if ((returnMatch || retsubMatch || errMatch) && !wasReturn) {
       wasReturn = true;
       continue;
     }

--- a/tealview.js
+++ b/tealview.js
@@ -433,7 +433,7 @@ Graph.prototype.handleClicks = function() {
 
 function draw() {
   var g = new Graph(txt.value);
-  console.log('DOT graph\n', g.generateDot());
+  console.log(g.generateDot());
   var svg = nomnoml.renderSvg(g.generateNoml());
   graphWrapper.innerHTML = svg;
 

--- a/tealview.js
+++ b/tealview.js
@@ -55,6 +55,12 @@ Node.prototype.addChild = function(node) {
   this.children.push(node);
 }
 
+function Edge(to, condition, callsub) {
+  this.to = to;
+  this.condition = condition;
+  this.callsub = callsub;
+}
+
 /*
  * </Node>
  */
@@ -67,7 +73,7 @@ function Graph(code) {
   // Map node name -> node
   this.nodes = {};
 
-  // Map node name -> [node names]
+  // Map node name -> [Edge]
   this.edges = {};
 
   // Process branches and labels
@@ -84,7 +90,7 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
   var lines = code.split("\n");
   var wasReturn = false;
   var wasGoto = null;
-  var deadCodeCounter = 0
+  var deadCodeCounter = 0;
 
   var i = 0;
   for (i = 0; i < lines.length; i++) {
@@ -139,7 +145,7 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
           if (!this.edges[wasGoto]) {
             this.edges[wasGoto] = [];
           }
-          this.edges[wasGoto].push(label);
+          this.edges[wasGoto].push(new Edge(label, null, false));
           var node = new Node(label, deadCodeLines.join("\n"), i);
           this.nodes[label] = node;
           deadCodeCounter++;
@@ -148,6 +154,12 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
         wasGoto = null;
         continue;
       }
+
+      if (branchMatch) {
+        // Removes branch instruction from the block
+        block.pop();
+      }
+
       // Create a node named after the most recent label
       var node = new Node(lastLabel, block.join("\n"), i);
       this.nodes[lastLabel] = node;
@@ -165,7 +177,7 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
         }
         // there was return on previous line then do not create a new edge
         if (!wasReturn) {
-          this.edges[lastLabel].push(newLabel);
+          this.edges[lastLabel].push(new Edge(newLabel, null, false));
         }
 
         // Update lastLabel, which names the next block of code
@@ -176,7 +188,7 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
           this.edges[lastLabel] = [];
         }
         // Add an edge from the old to the new destination
-        this.edges[lastLabel].push(newLabel);
+        this.edges[lastLabel].push(new Edge(newLabel, null, false));
         wasGoto = lastLabel;
         lastLabel = newLabel;
       } else if (branchMatch || callsubMatch) {
@@ -189,8 +201,19 @@ Graph.prototype.splitBranchesAndLabels = function(code) {
         if (!this.edges[lastLabel]) {
           this.edges[lastLabel] = [];
         }
-        this.edges[lastLabel].push(edge);
-        this.edges[lastLabel].push(newLabel);
+        const isCallsub = !!callsubMatch;
+        let targetCondition = null;
+        let fallthroughCondition = null;
+        if (branchMatch) {
+          if (branchMatch[0].startsWith("bz")) {
+            targetCondition = false;
+          } else {
+            targetCondition = true;
+          }
+          fallthroughCondition = !targetCondition;
+        }
+        this.edges[lastLabel].push(new Edge(edge, targetCondition, isCallsub));
+        this.edges[lastLabel].push(new Edge(newLabel, fallthroughCondition, false));
 
         // Update lastLabel, which names the next block of code
         lastLabel = newLabel;
@@ -218,11 +241,47 @@ Graph.prototype.generateNoml = function() {
     var edges = self.edges[key];
     for (var i = 0; i < edges.length; i++) {
       var edge = ""
-      edge += "[" + key + "]->[" + edges[i] + "]";
+      edge += "[" + key + "]->[" + edges[i].to + "]";
       lines.push(edge);
     }
   });
 
+  return lines.join("\n")
+}
+
+Graph.prototype.generateDot = function() {
+  var lines = [
+    "digraph {",
+    "node [shape=box]",
+  ];
+  var self = this;
+
+  // Add code sections
+  Object.keys(self.nodes).forEach(function(key) {
+    const node = self.nodes[key];
+    let code = node.code.replaceAll("\n", "\\n");
+    if (!node.name.startsWith("fallthru_")) {
+      code = node.name + ":\\n" + code;
+    }
+    lines.push(key + " [label=\"" + code + "\"]");
+  });
+
+  Object.keys(self.edges).forEach(function(key) {
+    var edges = self.edges[key];
+    for (var i = 0; i < edges.length; i++) {
+      var edge = ""
+      edge += key + " -> " + edges[i].to;
+      if (edges[i].condition != null) {
+        edge += " [label=\"" + edges[i].condition + "\"]";
+      }
+      if (edges[i].callsub) {
+        edge += " [dir=both]"
+      }
+      lines.push(edge);
+    }
+  });
+
+  lines.push("}");
   return lines.join("\n")
 }
 
@@ -374,6 +433,7 @@ Graph.prototype.handleClicks = function() {
 
 function draw() {
   var g = new Graph(txt.value);
+  console.log('DOT graph\n', g.generateDot());
   var svg = nomnoml.renderSvg(g.generateNoml());
   graphWrapper.innerHTML = svg;
 


### PR DESCRIPTION
# Summary

This PR adds support for generating Graphviz graph using the DOT language.

The generated graph is printed to the console, so you will need to copy that into your choice of Graphviz visualization software (e.g. https://dreampuf.github.io/GraphvizOnline).

I also modified the graph parsing code to create something a bit more natural, with conditional branch instructions removed in favor of labeling the edges with true or false.

# Example

Here's an example program:

```
#pragma version 8
// add two integers
int 1
int 2
+
// must be equal 3
int 3
==
bnz ok
// error if not equal
err
ok:
// return 1
int 1
```

With this PR, when you enter that program into tealviewer, the console will output:

```dot
digraph {
node [shape=box]
entry [label="entry:\nint 1\nint 2\n+\nint 3\n=="]
fallthru_8_bnz_ok [label="err"]
ok [label="ok:\nint 1"]
entry -> ok [label="true"]
entry -> fallthru_8_bnz_ok [label="false"]
}
```

Which can be visualized as:

![graphviz](https://github.com/algorand/tealviewer/assets/5856867/de33fd46-1e38-4f73-89d3-c0e170a4a566)

# Disclaimer

It's not production ready but I thought it might be useful to share.